### PR TITLE
introduce attribute for starting position in degree

### DIFF
--- a/library/src/main/java/com/github/lzyzsd/circleprogress/DonutProgress.java
+++ b/library/src/main/java/com/github/lzyzsd/circleprogress/DonutProgress.java
@@ -384,6 +384,7 @@ public class DonutProgress extends View {
         bundle.putInt(INSTANCE_FINISHED_STROKE_COLOR, getFinishedStrokeColor());
         bundle.putInt(INSTANCE_UNFINISHED_STROKE_COLOR, getUnfinishedStrokeColor());
         bundle.putInt(INSTANCE_MAX, getMax());
+        bundle.putInt(INSTANCE_STARTING_DEGREE, getStartingDegree());
         bundle.putInt(INSTANCE_PROGRESS, getProgress());
         bundle.putString(INSTANCE_SUFFIX, getSuffixText());
         bundle.putString(INSTANCE_PREFIX, getPrefixText());
@@ -410,6 +411,7 @@ public class DonutProgress extends View {
             innerBackgroundColor = bundle.getInt(INSTANCE_BACKGROUND_COLOR);
             initPainters();
             setMax(bundle.getInt(INSTANCE_MAX));
+            setStartingDegree(bundle.getInt(INSTANCE_STARTING_DEGREE));
             setProgress(bundle.getInt(INSTANCE_PROGRESS));
             prefixText = bundle.getString(INSTANCE_PREFIX);
             suffixText = bundle.getString(INSTANCE_SUFFIX);

--- a/library/src/main/java/com/github/lzyzsd/circleprogress/DonutProgress.java
+++ b/library/src/main/java/com/github/lzyzsd/circleprogress/DonutProgress.java
@@ -33,6 +33,7 @@ public class DonutProgress extends View {
     private int max;
     private int finishedStrokeColor;
     private int unfinishedStrokeColor;
+    private int startingDegree;
     private float finishedStrokeWidth;
     private float unfinishedStrokeWidth;
     private int innerBackgroundColor;
@@ -50,6 +51,7 @@ public class DonutProgress extends View {
     private final int default_inner_bottom_text_color = Color.rgb(66, 145, 241);
     private final int default_inner_background_color = Color.TRANSPARENT;
     private final int default_max = 100;
+    private final int default_startingDegree = 0;
     private final float default_text_size;
     private final float default_inner_bottom_text_size;
     private final int min_size;
@@ -71,6 +73,7 @@ public class DonutProgress extends View {
     private static final String INSTANCE_FINISHED_STROKE_WIDTH = "finished_stroke_width";
     private static final String INSTANCE_UNFINISHED_STROKE_WIDTH = "unfinished_stroke_width";
     private static final String INSTANCE_BACKGROUND_COLOR = "inner_background_color";
+    private static final String INSTANCE_STARTING_DEGREE = "starting_degree";
 
     public DonutProgress(Context context) {
         this(context, null);
@@ -147,6 +150,8 @@ public class DonutProgress extends View {
         innerBottomTextSize = attributes.getDimension(R.styleable.DonutProgress_donut_inner_bottom_text_size, default_inner_bottom_text_size);
         innerBottomTextColor = attributes.getColor(R.styleable.DonutProgress_donut_inner_bottom_text_color, default_inner_bottom_text_color);
         innerBottomText = attributes.getString(R.styleable.DonutProgress_donut_inner_bottom_text);
+
+        startingDegree = attributes.getInt(R.styleable.DonutProgress_donut_circle_starting_degree, default_startingDegree);
     }
 
     @Override
@@ -301,7 +306,14 @@ public class DonutProgress extends View {
         this.invalidate();
     }
 
+    public int getStartingDegree() {
+        return startingDegree;
+    }
 
+    public void setStartingDegree(int startingDegree) {
+        this.startingDegree = startingDegree;
+        this.invalidate();
+    }
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
@@ -342,8 +354,8 @@ public class DonutProgress extends View {
 
         float innerCircleRadius = (getWidth() - Math.min(finishedStrokeWidth, unfinishedStrokeWidth) + Math.abs(finishedStrokeWidth - unfinishedStrokeWidth)) / 2f;
         canvas.drawCircle(getWidth() / 2.0f, getHeight() / 2.0f, innerCircleRadius, innerCirclePaint);
-        canvas.drawArc(finishedOuterRect, 0, getProgressAngle(), false, finishedPaint);
-        canvas.drawArc(unfinishedOuterRect, getProgressAngle(), 360 - getProgressAngle(), false, unfinishedPaint);
+        canvas.drawArc(finishedOuterRect, getStartingDegree(), getProgressAngle(), false, finishedPaint);
+        canvas.drawArc(unfinishedOuterRect, getStartingDegree() + getProgressAngle(), 360 - getProgressAngle(), false, unfinishedPaint);
 
         String text = this.text != null ? this.text : prefixText + progress + suffixText;
         if (!TextUtils.isEmpty(text)) {

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -36,6 +36,8 @@
         <attr name="donut_inner_bottom_text" format="string"/>
         <attr name="donut_inner_bottom_text_size" format="dimension"/>
         <attr name="donut_inner_bottom_text_color" format="color"/>
+
+        <attr name="donut_circle_starting_degree" format="integer" />
     </declare-styleable>
 
     <declare-styleable name="ArcProgress">


### PR DESCRIPTION
because of the need to change the starting position I added an attribute for setting the starting position in degree.
it is now possible to specify `donut_circle_starting_degree="270"` to set the starting position to 12'o clock. Since degree is mod 360 it is also possible to `donut_cicle_starting_degree="-90"`