### PR TITLE
-Update to android version 26 and add support for VectorDrawablesCompat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Android Arsenal](https://img.shields.io/badge/Android+Arsenal-CircleProgress-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1130)
 
+A Fork of [https://github.com/lzyzsd/CircleProgress](https://github.com/lzyzsd/CircleProgress) to support `VectorDrawable` and other updates.
+
 inspired from
 [https://github.com/daimajia/NumberProgressBar](https://github.com/daimajia/NumberProgressBar)
 
@@ -32,7 +34,7 @@ please use jitpack
 
 ```groovy
 dependencies {
-    compile 'com.github.lzyzsd:circleprogress:1.2.1'
+    compile 'com.github.JimVanG:donutprogress:1.2.2'
 }
 ```
 
@@ -138,12 +140,11 @@ attrs for ArchProgress
 
 donut_inner_drawable
 
-support add a drawable to the center
+support add a drawable to the center (now supports `VectorDrawable`s)
 
 donut_show_text
 
 show or hide bottom text
-
 
 ###Build
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ please use jitpack
 
 ```groovy
 dependencies {
-    compile 'com.github.JimVanG:donutprogress:1.2.2'
+    compile 'com.github.JimVanG:donutprogress:1.2.3'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,15 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-rc2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 21
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 2
         versionName "1.0.1"
     }
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:21.0.3'
-    compile 'com.android.support:support-v4:21.0.3'
+    compile 'com.android.support:appcompat-v7:26.0.0'
+    compile 'com.android.support:support-v4:26.0.0'
 }

--- a/example/src/main/java/com/github/lzyzsd/circleprogressexample/ArcInFragment.java
+++ b/example/src/main/java/com/github/lzyzsd/circleprogressexample/ArcInFragment.java
@@ -1,36 +1,41 @@
 package com.github.lzyzsd.circleprogressexample;
 
-import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 
 
-public class ArcInFragment extends ActionBarActivity {
+public class ArcInFragment extends AppCompatActivity
+{
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState)
+    {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_arc_in_fragment);
     }
 
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(Menu menu)
+    {
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.menu_arc_in, menu);
         return true;
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(MenuItem item)
+    {
         // Handle action bar item clicks here. The action bar will
         // automatically handle clicks on the Home/Up button, so long
         // as you specify a parent activity in AndroidManifest.xml.
         int id = item.getItemId();
 
         //noinspection SimplifiableIfStatement
-        if (id == R.id.action_settings) {
+        if (id == R.id.action_settings)
+        {
             return true;
         }
 

--- a/example/src/main/java/com/github/lzyzsd/circleprogressexample/ItemDetailActivity.java
+++ b/example/src/main/java/com/github/lzyzsd/circleprogressexample/ItemDetailActivity.java
@@ -2,8 +2,8 @@ package com.github.lzyzsd.circleprogressexample;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
 import android.support.v4.app.NavUtils;
+import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 
@@ -16,10 +16,12 @@ import android.view.MenuItem;
  * This activity is mostly just a 'shell' activity containing nothing
  * more than a {@link ItemDetailFragment}.
  */
-public class ItemDetailActivity extends ActionBarActivity {
+public class ItemDetailActivity extends AppCompatActivity
+{
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState)
+    {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_item_detail);
 
@@ -35,24 +37,27 @@ public class ItemDetailActivity extends ActionBarActivity {
         //
         // http://developer.android.com/guide/components/fragments.html
         //
-        if (savedInstanceState == null) {
+        if (savedInstanceState == null)
+        {
             // Create the detail fragment and add it to the activity
             // using a fragment transaction.
             Bundle arguments = new Bundle();
             arguments.putString(ItemDetailFragment.ARG_ITEM_ID,
-                getIntent().getStringExtra(ItemDetailFragment.ARG_ITEM_ID));
+                                getIntent().getStringExtra(ItemDetailFragment.ARG_ITEM_ID));
             ItemDetailFragment fragment = new ItemDetailFragment();
             fragment.setArguments(arguments);
             getSupportFragmentManager().beginTransaction()
-                .add(R.id.item_detail_container, fragment)
-                .commit();
+                    .add(R.id.item_detail_container, fragment)
+                    .commit();
         }
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(MenuItem item)
+    {
         int id = item.getItemId();
-        if (id == android.R.id.home) {
+        if (id == android.R.id.home)
+        {
             // This ID represents the Home or Up button. In the case of this
             // activity, the Up button is shown. Use NavUtils to allow users
             // to navigate up one level in the application structure. For

--- a/example/src/main/java/com/github/lzyzsd/circleprogressexample/MyActivity.java
+++ b/example/src/main/java/com/github/lzyzsd/circleprogressexample/MyActivity.java
@@ -7,7 +7,7 @@ import android.annotation.TargetApi;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.animation.DecelerateInterpolator;
@@ -19,7 +19,8 @@ import com.github.lzyzsd.circleprogress.DonutProgress;
 import java.util.Timer;
 import java.util.TimerTask;
 
-public class MyActivity extends ActionBarActivity {
+public class MyActivity extends AppCompatActivity
+{
     private Timer timer;
     private DonutProgress donutProgress;
     private CircleProgress circleProgress;
@@ -27,7 +28,8 @@ public class MyActivity extends ActionBarActivity {
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState)
+    {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_my);
         donutProgress = (DonutProgress) findViewById(R.id.donut_progress);
@@ -48,20 +50,29 @@ public class MyActivity extends ActionBarActivity {
         animator.start();*/
 
         timer = new Timer();
-        timer.schedule(new TimerTask() {
+        timer.schedule(new TimerTask()
+        {
             @Override
-            public void run() {
-                runOnUiThread(new Runnable() {
+            public void run()
+            {
+                runOnUiThread(new Runnable()
+                {
                     @Override
-                    public void run() {
+                    public void run()
+                    {
                         boolean a = false;
-                        if (a) {
-                            ObjectAnimator anim = ObjectAnimator.ofInt(donutProgress, "progress", 0, 10);
+                        if (a)
+                        {
+                            ObjectAnimator anim = ObjectAnimator
+                                    .ofInt(donutProgress, "progress", 0, 10);
                             anim.setInterpolator(new DecelerateInterpolator());
                             anim.setDuration(500);
                             anim.start();
-                        } else {
-                            AnimatorSet set = (AnimatorSet) AnimatorInflater.loadAnimator(MyActivity.this, R.animator.progress_anim);
+                        }
+                        else
+                        {
+                            AnimatorSet set = (AnimatorSet) AnimatorInflater
+                                    .loadAnimator(MyActivity.this, R.animator.progress_anim);
                             set.setInterpolator(new DecelerateInterpolator());
                             set.setTarget(donutProgress);
                             set.start();
@@ -73,21 +84,25 @@ public class MyActivity extends ActionBarActivity {
     }
 
     @Override
-    protected void onDestroy() {
+    protected void onDestroy()
+    {
         super.onDestroy();
         timer.cancel();
     }
 
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(Menu menu)
+    {
         getMenuInflater().inflate(R.menu.my, menu);
         return true;
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
+    public boolean onOptionsItemSelected(MenuItem item)
+    {
+        switch (item.getItemId())
+        {
             case R.id.action_viewpager:
                 startActivity(new Intent(this, ViewPagerActivity.class));
                 return true;

--- a/example/src/main/java/com/github/lzyzsd/circleprogressexample/ViewPagerActivity.java
+++ b/example/src/main/java/com/github/lzyzsd/circleprogressexample/ViewPagerActivity.java
@@ -1,28 +1,24 @@
 package com.github.lzyzsd.circleprogressexample;
 
-import java.util.Locale;
-
-import android.support.v7.app.ActionBarActivity;
-import android.support.v7.app.ActionBar;
+import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.FragmentPagerAdapter;
-import android.os.Bundle;
 import android.support.v4.view.ViewPager;
-import android.view.Gravity;
+import android.support.v7.app.AppCompatActivity;
 import android.view.LayoutInflater;
 import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.TextView;
 
 import com.github.lzyzsd.circleprogress.ArcProgress;
 
+import java.util.Locale;
 
-public class ViewPagerActivity extends ActionBarActivity {
+
+public class ViewPagerActivity extends AppCompatActivity
+{
 
     /**
      * The {@link android.support.v4.view.PagerAdapter} that will provide
@@ -40,7 +36,8 @@ public class ViewPagerActivity extends ActionBarActivity {
     ViewPager mViewPager;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState)
+    {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_view_pager);
 
@@ -52,12 +49,12 @@ public class ViewPagerActivity extends ActionBarActivity {
         // Set up the ViewPager with the sections adapter.
         mViewPager = (ViewPager) findViewById(R.id.pager);
         mViewPager.setAdapter(mSectionsPagerAdapter);
-
     }
 
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(Menu menu)
+    {
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.menu_view_pager, menu);
         return true;
@@ -67,29 +64,35 @@ public class ViewPagerActivity extends ActionBarActivity {
      * A {@link FragmentPagerAdapter} that returns a fragment corresponding to
      * one of the sections/tabs/pages.
      */
-    public class SectionsPagerAdapter extends FragmentPagerAdapter {
+    public class SectionsPagerAdapter extends FragmentPagerAdapter
+    {
 
-        public SectionsPagerAdapter(FragmentManager fm) {
+        public SectionsPagerAdapter(FragmentManager fm)
+        {
             super(fm);
         }
 
         @Override
-        public Fragment getItem(int position) {
+        public Fragment getItem(int position)
+        {
             // getItem is called to instantiate the fragment for the given page.
             // Return a PlaceholderFragment (defined as a static inner class below).
             return PlaceholderFragment.newInstance(position + 1);
         }
 
         @Override
-        public int getCount() {
+        public int getCount()
+        {
             // Show 3 total pages.
             return 3;
         }
 
         @Override
-        public CharSequence getPageTitle(int position) {
+        public CharSequence getPageTitle(int position)
+        {
             Locale l = Locale.getDefault();
-            switch (position) {
+            switch (position)
+            {
                 case 0:
                     return getString(R.string.title_section1).toUpperCase(l);
                 case 1:
@@ -104,7 +107,8 @@ public class ViewPagerActivity extends ActionBarActivity {
     /**
      * A placeholder fragment containing a simple view.
      */
-    public static class PlaceholderFragment extends Fragment {
+    public static class PlaceholderFragment extends Fragment
+    {
         /**
          * The fragment argument representing the section number for this
          * fragment.
@@ -115,7 +119,8 @@ public class ViewPagerActivity extends ActionBarActivity {
          * Returns a new instance of this fragment for the given section
          * number.
          */
-        public static PlaceholderFragment newInstance(int sectionNumber) {
+        public static PlaceholderFragment newInstance(int sectionNumber)
+        {
             PlaceholderFragment fragment = new PlaceholderFragment();
             Bundle args = new Bundle();
             args.putInt(ARG_SECTION_NUMBER, sectionNumber);
@@ -123,23 +128,28 @@ public class ViewPagerActivity extends ActionBarActivity {
             return fragment;
         }
 
-        public PlaceholderFragment() {
+        public PlaceholderFragment()
+        {
         }
 
         @Override
-        public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                                 Bundle savedInstanceState) {
+        public View onCreateView(
+                LayoutInflater inflater, ViewGroup container,
+                Bundle savedInstanceState)
+        {
             View rootView = inflater.inflate(R.layout.fragment_view_pager, container, false);
             final ArcProgress arcProgress = (ArcProgress) rootView.findViewById(R.id.arc_progress);
             arcProgress.setProgress(20);
-            ((Button) rootView.findViewById(R.id.button_increase)).setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    arcProgress.setProgress(arcProgress.getProgress() + 1);
-                }
-            });
+            ((Button) rootView.findViewById(R.id.button_increase))
+                    .setOnClickListener(new View.OnClickListener()
+                    {
+                        @Override
+                        public void onClick(View view)
+                        {
+                            arcProgress.setProgress(arcProgress.getProgress() + 1);
+                        }
+                    });
             return rootView;
         }
     }
-
 }

--- a/example/src/main/res/drawable-anydpi/ic_cloud_download_black_24dp.xml
+++ b/example/src/main/res/drawable-anydpi/ic_cloud_download_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+            android:fillColor="#000000"
+            android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM17,13l-5,5 -5,-5h3V9h4v4h3z"/>
+</vector>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Sep 25 16:30:33 CST 2016
+#Tue Aug 08 04:49:22 CDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 
-version = "1.2.0"
+version = "1.2.3"
 
 android {
     compileSdkVersion 26

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,19 +3,25 @@ apply plugin: 'com.android.library'
 version = "1.2.0"
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 21
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 5
         versionName version
+
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    dependencies {
+        compile 'com.android.support:appcompat-v7:26.0.0'
     }
 }

--- a/library/src/main/java/com/github/lzyzsd/circleprogress/DonutProgress.java
+++ b/library/src/main/java/com/github/lzyzsd/circleprogress/DonutProgress.java
@@ -209,10 +209,7 @@ public class DonutProgress extends View
 
     protected void initInnerBitmap()
     {
-        if (attributeResourceId != 0)
-        {
-            bitmap = Utils.getBitmap(getContext(), attributeResourceId);
-        }
+        initInnerBitmap(getContext());
     }
 
     @Override
@@ -555,6 +552,7 @@ public class DonutProgress extends View
             unfinishedStrokeWidth = bundle.getFloat(INSTANCE_UNFINISHED_STROKE_WIDTH);
             innerBackgroundColor = bundle.getInt(INSTANCE_BACKGROUND_COLOR);
             attributeResourceId = bundle.getInt(INSTANCE_INNER_DRAWABLE);
+            initInnerBitmap();
             initPainters();
             setMax(bundle.getInt(INSTANCE_MAX));
             setStartingDegree(bundle.getInt(INSTANCE_STARTING_DEGREE));

--- a/library/src/main/java/com/github/lzyzsd/circleprogress/DonutProgress.java
+++ b/library/src/main/java/com/github/lzyzsd/circleprogress/DonutProgress.java
@@ -3,7 +3,6 @@ package com.github.lzyzsd.circleprogress;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -18,7 +17,8 @@ import android.view.View;
 /**
  * Created by bruce on 14-10-30.
  */
-public class DonutProgress extends View {
+public class DonutProgress extends View
+{
     private Paint finishedPaint;
     private Paint unfinishedPaint;
     private Paint innerCirclePaint;
@@ -30,6 +30,7 @@ public class DonutProgress extends View {
     private RectF unfinishedOuterRect = new RectF();
 
     private int attributeResourceId = 0;
+    private Bitmap bitmap;
     private boolean showText;
     private float textSize;
     private int textColor;
@@ -81,15 +82,18 @@ public class DonutProgress extends View {
     private static final String INSTANCE_STARTING_DEGREE = "starting_degree";
     private static final String INSTANCE_INNER_DRAWABLE = "inner_drawable";
 
-    public DonutProgress(Context context) {
+    public DonutProgress(Context context)
+    {
         this(context, null);
     }
 
-    public DonutProgress(Context context, AttributeSet attrs) {
+    public DonutProgress(Context context, AttributeSet attrs)
+    {
         this(context, attrs, 0);
     }
 
-    public DonutProgress(Context context, AttributeSet attrs, int defStyleAttr) {
+    public DonutProgress(Context context, AttributeSet attrs, int defStyleAttr)
+    {
         super(context, attrs, defStyleAttr);
 
         default_text_size = Utils.sp2px(getResources(), 18);
@@ -97,15 +101,20 @@ public class DonutProgress extends View {
         default_stroke_width = Utils.dp2px(getResources(), 10);
         default_inner_bottom_text_size = Utils.sp2px(getResources(), 18);
 
-        final TypedArray attributes = context.getTheme().obtainStyledAttributes(attrs, R.styleable.DonutProgress, defStyleAttr, 0);
+        final TypedArray attributes = context.getTheme()
+                .obtainStyledAttributes(attrs, R.styleable.DonutProgress, defStyleAttr, 0);
         initByAttributes(attributes);
         attributes.recycle();
+        //Init the inner bitmap, we don't want to do this inside onDraw().
+        initInnerBitmap(context);
 
         initPainters();
     }
 
-    protected void initPainters() {
-        if (showText) {
+    protected void initPainters()
+    {
+        if (showText)
+        {
             textPaint = new TextPaint();
             textPaint.setColor(textColor);
             textPaint.setTextSize(textSize);
@@ -134,237 +143,320 @@ public class DonutProgress extends View {
         innerCirclePaint.setAntiAlias(true);
     }
 
-    protected void initByAttributes(TypedArray attributes) {
-        finishedStrokeColor = attributes.getColor(R.styleable.DonutProgress_donut_finished_color, default_finished_color);
-        unfinishedStrokeColor = attributes.getColor(R.styleable.DonutProgress_donut_unfinished_color, default_unfinished_color);
+    protected void initByAttributes(TypedArray attributes)
+    {
+        finishedStrokeColor = attributes
+                .getColor(R.styleable.DonutProgress_donut_finished_color, default_finished_color);
+        unfinishedStrokeColor = attributes
+                .getColor(R.styleable.DonutProgress_donut_unfinished_color, default_unfinished_color);
         showText = attributes.getBoolean(R.styleable.DonutProgress_donut_show_text, true);
-        attributeResourceId = attributes.getResourceId(R.styleable.DonutProgress_donut_inner_drawable, 0);
+        attributeResourceId = attributes
+                .getResourceId(R.styleable.DonutProgress_donut_inner_drawable, 0);
 
         setMax(attributes.getInt(R.styleable.DonutProgress_donut_max, default_max));
         setProgress(attributes.getFloat(R.styleable.DonutProgress_donut_progress, 0));
-        finishedStrokeWidth = attributes.getDimension(R.styleable.DonutProgress_donut_finished_stroke_width, default_stroke_width);
-        unfinishedStrokeWidth = attributes.getDimension(R.styleable.DonutProgress_donut_unfinished_stroke_width, default_stroke_width);
+        finishedStrokeWidth = attributes
+                .getDimension(R.styleable.DonutProgress_donut_finished_stroke_width, default_stroke_width);
+        unfinishedStrokeWidth = attributes
+                .getDimension(R.styleable.DonutProgress_donut_unfinished_stroke_width, default_stroke_width);
 
-        if (showText) {
-            if (attributes.getString(R.styleable.DonutProgress_donut_prefix_text) != null) {
+        if (showText)
+        {
+            if (attributes.getString(R.styleable.DonutProgress_donut_prefix_text) != null)
+            {
                 prefixText = attributes.getString(R.styleable.DonutProgress_donut_prefix_text);
             }
-            if (attributes.getString(R.styleable.DonutProgress_donut_suffix_text) != null) {
+            if (attributes.getString(R.styleable.DonutProgress_donut_suffix_text) != null)
+            {
                 suffixText = attributes.getString(R.styleable.DonutProgress_donut_suffix_text);
             }
-            if (attributes.getString(R.styleable.DonutProgress_donut_text) != null) {
+            if (attributes.getString(R.styleable.DonutProgress_donut_text) != null)
+            {
                 text = attributes.getString(R.styleable.DonutProgress_donut_text);
             }
 
-            textColor = attributes.getColor(R.styleable.DonutProgress_donut_text_color, default_text_color);
-            textSize = attributes.getDimension(R.styleable.DonutProgress_donut_text_size, default_text_size);
-            innerBottomTextSize = attributes.getDimension(R.styleable.DonutProgress_donut_inner_bottom_text_size, default_inner_bottom_text_size);
-            innerBottomTextColor = attributes.getColor(R.styleable.DonutProgress_donut_inner_bottom_text_color, default_inner_bottom_text_color);
-            innerBottomText = attributes.getString(R.styleable.DonutProgress_donut_inner_bottom_text);
+            textColor = attributes
+                    .getColor(R.styleable.DonutProgress_donut_text_color, default_text_color);
+            textSize = attributes
+                    .getDimension(R.styleable.DonutProgress_donut_text_size, default_text_size);
+            innerBottomTextSize = attributes
+                    .getDimension(R.styleable.DonutProgress_donut_inner_bottom_text_size, default_inner_bottom_text_size);
+            innerBottomTextColor = attributes
+                    .getColor(R.styleable.DonutProgress_donut_inner_bottom_text_color, default_inner_bottom_text_color);
+            innerBottomText = attributes
+                    .getString(R.styleable.DonutProgress_donut_inner_bottom_text);
         }
 
-        innerBottomTextSize = attributes.getDimension(R.styleable.DonutProgress_donut_inner_bottom_text_size, default_inner_bottom_text_size);
-        innerBottomTextColor = attributes.getColor(R.styleable.DonutProgress_donut_inner_bottom_text_color, default_inner_bottom_text_color);
+        innerBottomTextSize = attributes
+                .getDimension(R.styleable.DonutProgress_donut_inner_bottom_text_size, default_inner_bottom_text_size);
+        innerBottomTextColor = attributes
+                .getColor(R.styleable.DonutProgress_donut_inner_bottom_text_color, default_inner_bottom_text_color);
         innerBottomText = attributes.getString(R.styleable.DonutProgress_donut_inner_bottom_text);
 
-        startingDegree = attributes.getInt(R.styleable.DonutProgress_donut_circle_starting_degree, default_startingDegree);
-        innerBackgroundColor = attributes.getColor(R.styleable.DonutProgress_donut_background_color, default_inner_background_color);
+        startingDegree = attributes
+                .getInt(R.styleable.DonutProgress_donut_circle_starting_degree, default_startingDegree);
+        innerBackgroundColor = attributes
+                .getColor(R.styleable.DonutProgress_donut_background_color, default_inner_background_color);
+    }
+
+    protected void initInnerBitmap(Context context)
+    {
+        if (attributeResourceId != 0)
+        {
+            bitmap = Utils.getBitmap(context, attributeResourceId);
+        }
+    }
+
+    protected void initInnerBitmap()
+    {
+        if (attributeResourceId != 0)
+        {
+            bitmap = Utils.getBitmap(getContext(), attributeResourceId);
+        }
     }
 
     @Override
-    public void invalidate() {
+    public void invalidate()
+    {
         initPainters();
         super.invalidate();
     }
 
-    public boolean isShowText() {
+    public boolean isShowText()
+    {
         return showText;
     }
 
-    public void setShowText(boolean showText) {
+    public void setShowText(boolean showText)
+    {
         this.showText = showText;
     }
 
-    public float getFinishedStrokeWidth() {
+    public float getFinishedStrokeWidth()
+    {
         return finishedStrokeWidth;
     }
 
-    public void setFinishedStrokeWidth(float finishedStrokeWidth) {
+    public void setFinishedStrokeWidth(float finishedStrokeWidth)
+    {
         this.finishedStrokeWidth = finishedStrokeWidth;
         this.invalidate();
     }
 
-    public float getUnfinishedStrokeWidth() {
+    public float getUnfinishedStrokeWidth()
+    {
         return unfinishedStrokeWidth;
     }
 
-    public void setUnfinishedStrokeWidth(float unfinishedStrokeWidth) {
+    public void setUnfinishedStrokeWidth(float unfinishedStrokeWidth)
+    {
         this.unfinishedStrokeWidth = unfinishedStrokeWidth;
         this.invalidate();
     }
 
-    private float getProgressAngle() {
+    private float getProgressAngle()
+    {
         return getProgress() / (float) max * 360f;
     }
 
-    public float getProgress() {
+    public float getProgress()
+    {
         return progress;
     }
 
-    public void setProgress(float progress) {
+    public void setProgress(float progress)
+    {
         this.progress = progress;
-        if (this.progress > getMax()) {
+        if (this.progress > getMax())
+        {
             this.progress %= getMax();
         }
         invalidate();
     }
 
-    public int getMax() {
+    public int getMax()
+    {
         return max;
     }
 
-    public void setMax(int max) {
-        if (max > 0) {
+    public void setMax(int max)
+    {
+        if (max > 0)
+        {
             this.max = max;
             invalidate();
         }
     }
 
-    public float getTextSize() {
+    public float getTextSize()
+    {
         return textSize;
     }
 
-    public void setTextSize(float textSize) {
+    public void setTextSize(float textSize)
+    {
         this.textSize = textSize;
         this.invalidate();
     }
 
-    public int getTextColor() {
+    public int getTextColor()
+    {
         return textColor;
     }
 
-    public void setTextColor(int textColor) {
+    public void setTextColor(int textColor)
+    {
         this.textColor = textColor;
         this.invalidate();
     }
 
-    public int getFinishedStrokeColor() {
+    public int getFinishedStrokeColor()
+    {
         return finishedStrokeColor;
     }
 
-    public void setFinishedStrokeColor(int finishedStrokeColor) {
+    public void setFinishedStrokeColor(int finishedStrokeColor)
+    {
         this.finishedStrokeColor = finishedStrokeColor;
         this.invalidate();
     }
 
-    public int getUnfinishedStrokeColor() {
+    public int getUnfinishedStrokeColor()
+    {
         return unfinishedStrokeColor;
     }
 
-    public void setUnfinishedStrokeColor(int unfinishedStrokeColor) {
+    public void setUnfinishedStrokeColor(int unfinishedStrokeColor)
+    {
         this.unfinishedStrokeColor = unfinishedStrokeColor;
         this.invalidate();
     }
 
-    public String getText() {
+    public String getText()
+    {
         return text;
     }
 
-    public void setText(String text) {
+    public void setText(String text)
+    {
         this.text = text;
         this.invalidate();
     }
 
-    public String getSuffixText() {
+    public String getSuffixText()
+    {
         return suffixText;
     }
 
-    public void setSuffixText(String suffixText) {
+    public void setSuffixText(String suffixText)
+    {
         this.suffixText = suffixText;
         this.invalidate();
     }
 
-    public String getPrefixText() {
+    public String getPrefixText()
+    {
         return prefixText;
     }
 
-    public void setPrefixText(String prefixText) {
+    public void setPrefixText(String prefixText)
+    {
         this.prefixText = prefixText;
         this.invalidate();
     }
 
-    public int getInnerBackgroundColor() {
+    public int getInnerBackgroundColor()
+    {
         return innerBackgroundColor;
     }
 
-    public void setInnerBackgroundColor(int innerBackgroundColor) {
+    public void setInnerBackgroundColor(int innerBackgroundColor)
+    {
         this.innerBackgroundColor = innerBackgroundColor;
         this.invalidate();
     }
 
 
-    public String getInnerBottomText() {
+    public String getInnerBottomText()
+    {
         return innerBottomText;
     }
 
-    public void setInnerBottomText(String innerBottomText) {
+    public void setInnerBottomText(String innerBottomText)
+    {
         this.innerBottomText = innerBottomText;
         this.invalidate();
     }
 
 
-    public float getInnerBottomTextSize() {
+    public float getInnerBottomTextSize()
+    {
         return innerBottomTextSize;
     }
 
-    public void setInnerBottomTextSize(float innerBottomTextSize) {
+    public void setInnerBottomTextSize(float innerBottomTextSize)
+    {
         this.innerBottomTextSize = innerBottomTextSize;
         this.invalidate();
     }
 
-    public int getInnerBottomTextColor() {
+    public int getInnerBottomTextColor()
+    {
         return innerBottomTextColor;
     }
 
-    public void setInnerBottomTextColor(int innerBottomTextColor) {
+    public void setInnerBottomTextColor(int innerBottomTextColor)
+    {
         this.innerBottomTextColor = innerBottomTextColor;
         this.invalidate();
     }
 
-    public int getStartingDegree() {
+    public int getStartingDegree()
+    {
         return startingDegree;
     }
 
-    public void setStartingDegree(int startingDegree) {
+    public void setStartingDegree(int startingDegree)
+    {
         this.startingDegree = startingDegree;
         this.invalidate();
     }
 
-    public int getAttributeResourceId() {
+    public int getAttributeResourceId()
+    {
         return attributeResourceId;
     }
 
-    public void setAttributeResourceId(int attributeResourceId) {
+    public void setAttributeResourceId(int attributeResourceId)
+    {
         this.attributeResourceId = attributeResourceId;
+        initInnerBitmap();
+        this.invalidate();
     }
 
     @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec)
+    {
         setMeasuredDimension(measure(widthMeasureSpec), measure(heightMeasureSpec));
 
         //TODO calculate inner circle height and then position bottom text at the bottom (3/4)
         innerBottomTextHeight = getHeight() - (getHeight() * 3) / 4;
     }
 
-    private int measure(int measureSpec) {
+    private int measure(int measureSpec)
+    {
         int result;
         int mode = MeasureSpec.getMode(measureSpec);
         int size = MeasureSpec.getSize(measureSpec);
-        if (mode == MeasureSpec.EXACTLY) {
+        if (mode == MeasureSpec.EXACTLY)
+        {
             result = size;
-        } else {
+        }
+        else
+        {
             result = min_size;
-            if (mode == MeasureSpec.AT_MOST) {
+            if (mode == MeasureSpec.AT_MOST)
+            {
                 result = Math.min(result, size);
             }
         }
@@ -372,46 +464,57 @@ public class DonutProgress extends View {
     }
 
     @Override
-    protected void onDraw(Canvas canvas) {
+    protected void onDraw(Canvas canvas)
+    {
         super.onDraw(canvas);
 
         float delta = Math.max(finishedStrokeWidth, unfinishedStrokeWidth);
         finishedOuterRect.set(delta,
-                delta,
-                getWidth() - delta,
-                getHeight() - delta);
+                              delta,
+                              getWidth() - delta,
+                              getHeight() - delta);
         unfinishedOuterRect.set(delta,
-                delta,
-                getWidth() - delta,
-                getHeight() - delta);
+                                delta,
+                                getWidth() - delta,
+                                getHeight() - delta);
 
-        float innerCircleRadius = (getWidth() - Math.min(finishedStrokeWidth, unfinishedStrokeWidth) + Math.abs(finishedStrokeWidth - unfinishedStrokeWidth)) / 2f;
+        float innerCircleRadius = (getWidth() - Math
+                .min(finishedStrokeWidth, unfinishedStrokeWidth) + Math
+                .abs(finishedStrokeWidth - unfinishedStrokeWidth)) / 2f;
         canvas.drawCircle(getWidth() / 2.0f, getHeight() / 2.0f, innerCircleRadius, innerCirclePaint);
         canvas.drawArc(finishedOuterRect, getStartingDegree(), getProgressAngle(), false, finishedPaint);
         canvas.drawArc(unfinishedOuterRect, getStartingDegree() + getProgressAngle(), 360 - getProgressAngle(), false, unfinishedPaint);
 
-        if (showText) {
+        if (showText)
+        {
             String text = this.text != null ? this.text : prefixText + progress + suffixText;
-            if (!TextUtils.isEmpty(text)) {
+            if (!TextUtils.isEmpty(text))
+            {
                 float textHeight = textPaint.descent() + textPaint.ascent();
-                canvas.drawText(text, (getWidth() - textPaint.measureText(text)) / 2.0f, (getWidth() - textHeight) / 2.0f, textPaint);
+                canvas.drawText(text, (getWidth() - textPaint
+                        .measureText(text)) / 2.0f, (getWidth() - textHeight) / 2.0f, textPaint);
             }
 
-            if (!TextUtils.isEmpty(getInnerBottomText())) {
+            if (!TextUtils.isEmpty(getInnerBottomText()))
+            {
                 innerBottomTextPaint.setTextSize(innerBottomTextSize);
-                float bottomTextBaseline = getHeight() - innerBottomTextHeight - (textPaint.descent() + textPaint.ascent()) / 2;
-                canvas.drawText(getInnerBottomText(), (getWidth() - innerBottomTextPaint.measureText(getInnerBottomText())) / 2.0f, bottomTextBaseline, innerBottomTextPaint);
+                float bottomTextBaseline = getHeight() - innerBottomTextHeight - (textPaint
+                        .descent() + textPaint.ascent()) / 2;
+                canvas.drawText(getInnerBottomText(), (getWidth() - innerBottomTextPaint
+                        .measureText(getInnerBottomText())) / 2.0f, bottomTextBaseline, innerBottomTextPaint);
             }
         }
 
-        if (attributeResourceId != 0) {
-            Bitmap bitmap = BitmapFactory.decodeResource(getResources(), attributeResourceId);
-            canvas.drawBitmap(bitmap, (getWidth() - bitmap.getWidth()) / 2.0f, (getHeight() - bitmap.getHeight()) / 2.0f, null);
+        if (bitmap != null)
+        {
+            canvas.drawBitmap(bitmap, (getWidth() - bitmap
+                    .getWidth()) / 2.0f, (getHeight() - bitmap.getHeight()) / 2.0f, null);
         }
     }
 
     @Override
-    protected Parcelable onSaveInstanceState() {
+    protected Parcelable onSaveInstanceState()
+    {
         final Bundle bundle = new Bundle();
         bundle.putParcelable(INSTANCE_STATE, super.onSaveInstanceState());
         bundle.putInt(INSTANCE_TEXT_COLOR, getTextColor());
@@ -436,8 +539,10 @@ public class DonutProgress extends View {
     }
 
     @Override
-    protected void onRestoreInstanceState(Parcelable state) {
-        if (state instanceof Bundle) {
+    protected void onRestoreInstanceState(Parcelable state)
+    {
+        if (state instanceof Bundle)
+        {
             final Bundle bundle = (Bundle) state;
             textColor = bundle.getInt(INSTANCE_TEXT_COLOR);
             textSize = bundle.getFloat(INSTANCE_TEXT_SIZE);
@@ -462,8 +567,11 @@ public class DonutProgress extends View {
         }
         super.onRestoreInstanceState(state);
     }
-     public void setDonut_progress(String percent){
-        if(!TextUtils.isEmpty(percent)){
+
+    public void setDonut_progress(String percent)
+    {
+        if (!TextUtils.isEmpty(percent))
+        {
             setProgress(Integer.parseInt(percent));
         }
     }

--- a/library/src/main/java/com/github/lzyzsd/circleprogress/Utils.java
+++ b/library/src/main/java/com/github/lzyzsd/circleprogress/Utils.java
@@ -8,7 +8,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.VectorDrawable;
 import android.support.graphics.drawable.VectorDrawableCompat;
-import android.support.v4.content.ContextCompat;
+import android.support.v7.content.res.AppCompatResources;
 
 /**
  * Created by bruce on 14-11-6.
@@ -34,7 +34,7 @@ public final class Utils
 
     public static Bitmap getBitmap(Context context, int drawableId)
     {
-        Drawable drawable = ContextCompat.getDrawable(context, drawableId);
+        Drawable drawable = AppCompatResources.getDrawable(context, drawableId);
         return Utils.getBitmap(drawable);
     }
 

--- a/library/src/main/java/com/github/lzyzsd/circleprogress/Utils.java
+++ b/library/src/main/java/com/github/lzyzsd/circleprogress/Utils.java
@@ -1,22 +1,62 @@
 package com.github.lzyzsd.circleprogress;
 
+import android.content.Context;
 import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.VectorDrawable;
+import android.support.graphics.drawable.VectorDrawableCompat;
+import android.support.v4.content.ContextCompat;
 
 /**
  * Created by bruce on 14-11-6.
  */
-public final class Utils {
-    
-    private Utils() {
-    }
-    
-    public static float dp2px(Resources resources, float dp) {
-        final float scale = resources.getDisplayMetrics().density;
-        return  dp * scale + 0.5f;
+public final class Utils
+{
+
+    private Utils()
+    {
     }
 
-    public static float sp2px(Resources resources, float sp){
+    public static float dp2px(Resources resources, float dp)
+    {
+        final float scale = resources.getDisplayMetrics().density;
+        return dp * scale + 0.5f;
+    }
+
+    public static float sp2px(Resources resources, float sp)
+    {
         final float scale = resources.getDisplayMetrics().scaledDensity;
         return sp * scale;
+    }
+
+    public static Bitmap getBitmap(Context context, int drawableId)
+    {
+        Drawable drawable = ContextCompat.getDrawable(context, drawableId);
+        return Utils.getBitmap(drawable);
+    }
+
+    public static Bitmap getBitmap(Drawable drawable)
+    {
+        if (drawable instanceof BitmapDrawable)
+        {
+            return ((BitmapDrawable) drawable).getBitmap();
+        }
+        else if (drawable instanceof VectorDrawableCompat || drawable instanceof VectorDrawable)
+        {
+            Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(),
+                                                drawable.getIntrinsicHeight(),
+                                                Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(bitmap);
+            drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+            drawable.draw(canvas);
+            return bitmap;
+        }
+        else
+        {
+            throw new IllegalArgumentException("unsupported drawable type");
+        }
     }
 }


### PR DESCRIPTION
This commit updates the targetSDKVersion to 26 and adds support for VectorDrawables via the support library. DonutProgress now accepts VectorDrawables as the `donut_inner_drawable` value. The `donut_inner_drawable`’s Bitmap initialization has been removed from onDraw() for better performance. 