### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ please use jitpack
 
 ```groovy
 dependencies {
-    compile 'com.github.lzyzsd:circleprogress:1.2.1'
+    implementation 'com.github.lzyzsd:circleprogress:1.2.1'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.